### PR TITLE
Include API gateway instructions and code

### DIFF
--- a/level-0/advanced/terraform/apigateway.tf
+++ b/level-0/advanced/terraform/apigateway.tf
@@ -1,0 +1,34 @@
+resource "aws_apigatewayv2_api" "main" {
+  name             = "my-api-gw-tf-${var.aws_user}"
+  description      = "The API Gateway for ${var.aws_user}"
+  protocol_type    = "HTTP"
+  fail_on_warnings = true
+}
+
+resource "aws_apigatewayv2_route" "root" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.root.id}"
+}
+
+resource "aws_apigatewayv2_integration" "root" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+  integration_uri        = aws_lambda_function.my_function.arn
+}
+
+resource "aws_apigatewayv2_stage" "main" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "main" {
+  statement_id  = "allow-invocation-by-api-gateway"
+  principal     = "apigateway.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.my_function.function_name
+  source_arn    = "${aws_apigatewayv2_stage.main.execution_arn}/$default"
+}

--- a/level-0/advanced/terraform/outputs.tf
+++ b/level-0/advanced/terraform/outputs.tf
@@ -2,3 +2,8 @@ output "function_name" {
   description = "Name of the Lambda function"
   value       = aws_lambda_function.my_function.function_name
 }
+
+output "invoke_url" {
+  description = "URL where the Lambda can be accessed through HTTP"
+  value       = aws_apigatewayv2_stage.main.invoke_url
+}

--- a/level-0/function/index.js
+++ b/level-0/function/index.js
@@ -1,1 +1,11 @@
-exports.handler = async () => `Hello, I am ${process.env.NAME}`;
+exports.handler = async (event, context, callback) => {
+  return {
+    statusCode: 200,
+    body: `Hello, I am ${process.env.NAME}`,
+    headers: {
+      "Content-Type": "text/plain",
+    },
+    multiValueHeader: {},
+    isBase64Encoded: false,
+  };
+};

--- a/level-1/advanced/terraform/apigateway.tf
+++ b/level-1/advanced/terraform/apigateway.tf
@@ -1,0 +1,34 @@
+resource "aws_apigatewayv2_api" "main" {
+  name             = "my-api-gw-tf-${var.aws_user}"
+  description      = "The API Gateway for ${var.aws_user}"
+  protocol_type    = "HTTP"
+  fail_on_warnings = true
+}
+
+resource "aws_apigatewayv2_route" "root" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.root.id}"
+}
+
+resource "aws_apigatewayv2_integration" "root" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+  integration_uri        = aws_lambda_function.my_function.arn
+}
+
+resource "aws_apigatewayv2_stage" "main" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "main" {
+  statement_id  = "allow-invocation-by-api-gateway"
+  principal     = "apigateway.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.my_function.function_name
+  source_arn    = "${aws_apigatewayv2_stage.main.execution_arn}/$default"
+}

--- a/level-1/advanced/terraform/outputs.tf
+++ b/level-1/advanced/terraform/outputs.tf
@@ -2,3 +2,8 @@ output "function_name" {
   description = "Name of the Lambda function"
   value       = aws_lambda_function.my_function.function_name
 }
+
+output "invoke_url" {
+  description = "URL where the Lambda can be accessed through HTTP"
+  value       = aws_apigatewayv2_stage.main.invoke_url
+}

--- a/level-1/function/index.js
+++ b/level-1/function/index.js
@@ -1,5 +1,13 @@
 exports.handler = async (event) => {
   console.log(`${event.name} invoked me`);
   console.error("Oh noes!");
-  return `Hello ${event.name}`;
+  return {
+    statusCode: 200,
+    body: `Hello ${event.name}`,
+    headers: {
+      "Content-Type": "text/plain",
+    },
+    multiValueHeader: {},
+    isBase64Encoded: false,
+  };
 };

--- a/level-2/advanced/terraform/apigateway.tf
+++ b/level-2/advanced/terraform/apigateway.tf
@@ -1,0 +1,34 @@
+resource "aws_apigatewayv2_api" "main" {
+  name             = "my-api-gw-tf-${var.aws_user}"
+  description      = "The API Gateway for ${var.aws_user}"
+  protocol_type    = "HTTP"
+  fail_on_warnings = true
+}
+
+resource "aws_apigatewayv2_route" "root" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.root.id}"
+}
+
+resource "aws_apigatewayv2_integration" "root" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+  integration_uri        = aws_lambda_function.my_function.arn
+}
+
+resource "aws_apigatewayv2_stage" "main" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "main" {
+  statement_id  = "allow-invocation-by-api-gateway"
+  principal     = "apigateway.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.my_function.function_name
+  source_arn    = "${aws_apigatewayv2_stage.main.execution_arn}/$default"
+}

--- a/level-2/advanced/terraform/outputs.tf
+++ b/level-2/advanced/terraform/outputs.tf
@@ -9,3 +9,8 @@ output "table_name" {
 
   value = aws_dynamodb_table.jokes.name
 }
+
+output "invoke_url" {
+  description = "URL where the Lambda can be accessed through HTTP"
+  value       = aws_apigatewayv2_stage.main.invoke_url
+}

--- a/level-2/function/index.js
+++ b/level-2/function/index.js
@@ -8,10 +8,18 @@ exports.handler = async (event) => {
 
   const ddb = AWSXRay.captureAWSv3Client(new DynamoDBClient());
 
+  let jokeID = event.jokeID;
+  if (event.body) {
+    const buff = Buffer.from(event.body, "base64");
+    const body = JSON.parse(buff.toString("utf-8"));
+
+    jokeID = body.jokeID;
+  }
   const cmd = new GetItemCommand({
     TableName: `jokes${tableSuffix}`,
-    Key: { ID: { N: event.jokeID } },
+    Key: { ID: { N: jokeID } },
   });
+
   const response = await ddb.send(cmd);
 
   return response.Item;

--- a/level-3/advanced/terraform/apigateway.tf
+++ b/level-3/advanced/terraform/apigateway.tf
@@ -1,0 +1,34 @@
+resource "aws_apigatewayv2_api" "main" {
+  name             = "my-api-gw-tf-${var.aws_user}"
+  description      = "The API Gateway for ${var.aws_user}"
+  protocol_type    = "HTTP"
+  fail_on_warnings = true
+}
+
+resource "aws_apigatewayv2_route" "root" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.root.id}"
+}
+
+resource "aws_apigatewayv2_integration" "root" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+  integration_uri        = aws_lambda_function.my_function.arn
+}
+
+resource "aws_apigatewayv2_stage" "main" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "main" {
+  statement_id  = "allow-invocation-by-api-gateway"
+  principal     = "apigateway.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.my_function.function_name
+  source_arn    = "${aws_apigatewayv2_stage.main.execution_arn}/$default"
+}

--- a/level-3/advanced/terraform/outputs.tf
+++ b/level-3/advanced/terraform/outputs.tf
@@ -9,3 +9,8 @@ output "table_name" {
 
   value = aws_dynamodb_table.jokes.name
 }
+
+output "invoke_url" {
+  description = "URL where the Lambda can be accessed through HTTP"
+  value       = aws_apigatewayv2_stage.main.invoke_url
+}

--- a/level-3/function/index.js
+++ b/level-3/function/index.js
@@ -18,10 +18,18 @@ exports.handler = async (event, context) => {
     )
   );
 
+  let jokeID = event.jokeID;
+  if (event.body) {
+    const buff = Buffer.from(event.body, "base64");
+    const body = JSON.parse(buff.toString("utf-8"));
+
+    jokeID = body.jokeID;
+  }
   const cmd = new GetItemCommand({
     TableName: `jokes${tableSuffix}`,
-    Key: { ID: { N: event.jokeID } },
+    Key: { ID: { N: jokeID } },
   });
+
   responsePromise = ddb.send(cmd);
 
   try {

--- a/level-4/advanced/terraform/apigateway.tf
+++ b/level-4/advanced/terraform/apigateway.tf
@@ -1,0 +1,34 @@
+resource "aws_apigatewayv2_api" "main" {
+  name             = "my-api-gw-tf-${var.aws_user}"
+  description      = "The API Gateway for ${var.aws_user}"
+  protocol_type    = "HTTP"
+  fail_on_warnings = true
+}
+
+resource "aws_apigatewayv2_route" "root" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.root.id}"
+}
+
+resource "aws_apigatewayv2_integration" "root" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+  integration_uri        = aws_lambda_function.my_function.arn
+}
+
+resource "aws_apigatewayv2_stage" "main" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "main" {
+  statement_id  = "allow-invocation-by-api-gateway"
+  principal     = "apigateway.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.my_function.function_name
+  source_arn    = "${aws_apigatewayv2_stage.main.execution_arn}/$default"
+}

--- a/level-4/advanced/terraform/outputs.tf
+++ b/level-4/advanced/terraform/outputs.tf
@@ -9,3 +9,8 @@ output "table_name" {
 
   value = aws_dynamodb_table.jokes.name
 }
+
+output "invoke_url" {
+  description = "URL where the Lambda can be accessed through HTTP"
+  value       = aws_apigatewayv2_stage.main.invoke_url
+}

--- a/level-4/function/index.js
+++ b/level-4/function/index.js
@@ -9,10 +9,18 @@ const tableSuffix = process.env.JOKE_TABLE_SUFFIX
 const ddb = AWSXRay.captureAWSv3Client(new DynamoDBClient());
 
 exports.handler = async (event) => {
+  let jokeID = event.jokeID;
+  if (event.body) {
+    const buff = Buffer.from(event.body, "base64");
+    const body = JSON.parse(buff.toString("utf-8"));
+
+    jokeID = body.jokeID;
+  }
   const cmd = new GetItemCommand({
     TableName: `jokes${tableSuffix}`,
-    Key: { ID: { N: event.jokeID } },
+    Key: { ID: { N: jokeID } },
   });
+
   const response = await ddb.send(cmd);
 
   return response.Item;

--- a/level-6/advanced/terraform/apigateway.tf
+++ b/level-6/advanced/terraform/apigateway.tf
@@ -1,0 +1,34 @@
+resource "aws_apigatewayv2_api" "main" {
+  name             = "my-api-gw-tf-${var.aws_user}"
+  description      = "The API Gateway for ${var.aws_user}"
+  protocol_type    = "HTTP"
+  fail_on_warnings = true
+}
+
+resource "aws_apigatewayv2_route" "root" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "$default"
+  target    = "integrations/${aws_apigatewayv2_integration.root.id}"
+}
+
+resource "aws_apigatewayv2_integration" "root" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+  integration_uri        = aws_lambda_function.my_function.arn
+}
+
+resource "aws_apigatewayv2_stage" "main" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "main" {
+  statement_id  = "allow-invocation-by-api-gateway"
+  principal     = "apigateway.amazonaws.com"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.my_function.function_name
+  source_arn    = "${aws_apigatewayv2_stage.main.execution_arn}/$default"
+}

--- a/level-6/advanced/terraform/outputs.tf
+++ b/level-6/advanced/terraform/outputs.tf
@@ -9,3 +9,8 @@ output "table_name" {
 
   value = aws_dynamodb_table.jokes.name
 }
+
+output "invoke_url" {
+  description = "URL where the Lambda can be accessed through HTTP"
+  value       = aws_apigatewayv2_stage.main.invoke_url
+}

--- a/level-6/function/index.js
+++ b/level-6/function/index.js
@@ -9,10 +9,18 @@ const tableSuffix = process.env.JOKE_TABLE_SUFFIX
 const ddb = AWSXRay.captureAWSv3Client(new DynamoDBClient());
 
 exports.handler = async (event) => {
+  let jokeID = event.jokeID;
+  if (event.body) {
+    const buff = Buffer.from(event.body, "base64");
+    const body = JSON.parse(buff.toString("utf-8"));
+
+    jokeID = body.jokeID;
+  }
   const cmd = new GetItemCommand({
     TableName: `jokes${tableSuffix}`,
-    Key: { ID: { N: event.jokeID } },
+    Key: { ID: { N: jokeID } },
   });
+
   const response = await ddb.send(cmd);
 
   return response.Item;


### PR DESCRIPTION
Includes instructions on creating an API gateway trigger through the UI, CLI or Terraform in level zero.
Adds the Terraform code required to levels 0 to 6, except 5, where a different function setup is used.

Changes the function code slightly, to support setting the content type correctly in levels 0 and 1 and then to properly read the payload body in levels 2, 3, 4, and 6.