### PR TITLE
Adjust wording to reflect current state of AWS IAM web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ We modify the function to read a joke from a joke table and change the function 
 
 1. Upload the zip file to the function by using the `Upload from` button
 1. In the `Configuration` tab, click `Permissions` and then click the link to the execution role
-1. Click the `Attach Policies` button and add the "AmazonDynamoDBReadOnlyAccess" and the "AWSXRayDaemonWriteAccess" permissions to grant your function access to DynamoDB and the X-Ray service
+1. Click the `Add permissions` button, select `Attach policies` and add the "AmazonDynamoDBReadOnlyAccess" and the "AWSXRayDaemonWriteAccess" permissions to grant your function access to DynamoDB and the X-Ray service
 1. In the `Configuration` tab of the lambda function, select the `Monitoring and operations tools`, click edit and enable `Active tracing` in the `AWS X-Ray` section
 1. On the function's `Test` tab, create a test event with the following payload `{ "jokeID": "1" }` and click the `Test` button. You should see the joke loaded from the database in the response
 1. On the `Monitor` tab, select the `Traces` menu option and inspect the service map as well as the individual traces. Click on one of the traces to get familiar of what info you have available, such as how long the request to query the DynamoDB took.

--- a/level-3/function/index.js
+++ b/level-3/function/index.js
@@ -11,7 +11,7 @@ exports.handler = async (event, context) => {
   const ddb = AWSXRay.captureAWSv3Client(new DynamoDBClient());
 
   // Abort before function times out
-  const timoutPromise = new Promise((_, reject) =>
+  const timeoutPromise = new Promise((_, reject) =>
     setTimeout(
       () => reject(new Error("Timeout")),
       context.getRemainingTimeInMillis() - TIMEOUT_GRACE_PERIOD_IN_MILLIS
@@ -33,7 +33,7 @@ exports.handler = async (event, context) => {
   responsePromise = ddb.send(cmd);
 
   try {
-    response = await Promise.race([timoutPromise, responsePromise]);
+    response = await Promise.race([timeoutPromise, responsePromise]);
     console.log(
       `Remaining time after db query is ${context.getRemainingTimeInMillis()}ms.`
     );


### PR DESCRIPTION
The `Permissions policy` section has a button called `Add permissions` which then displays the option to `Attach policies` in the associated drop-down menu.