### PR TITLE
Cleanup terraform commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,8 +1045,14 @@ Furthermore, you need to have valid credentials for your AWS user set up in your
 1. Initialize the Terraform module
 
    ```shell
-   terraform -chdir=my-tf-module init
+   terraform init
    ```
+
+1. Navigate back to the workshop repo
+
+  ```shell
+  popd
+  ```
 
 1. Set your AWS user name as an environment variable for Terraform
 
@@ -1057,9 +1063,9 @@ Furthermore, you need to have valid credentials for your AWS user set up in your
 1. Install the functions dependencies
 
    ```shell
-   cd my-tf-module/function
+   pushd my-tf-module/function
    npm install
-   cd ../..
+   popd
    ```
 
 1. Navigate to your Terraform module
@@ -1071,13 +1077,14 @@ Furthermore, you need to have valid credentials for your AWS user set up in your
 1. Apply the Terraform module
 
    ```shell
-   terraform -chdir=my-tf-module apply
+   terraform apply
    ```
 
 1. Invoke the function with a test event:
 
    ```shell
    aws lambda invoke --function-name "my-function-tf-${TF_VAR_aws_user}" --cli-binary-format raw-in-base64-out --payload '{ "jokeID": "1" }' output.json --log-type Tail
+   popd
    ```
 
 ## Level 7 - Testing ... duh!

--- a/README.md
+++ b/README.md
@@ -661,7 +661,7 @@ You will notice the following points:
 1. Copy the Terraform module and the function code from level 3
 
    ```shell
-   cp -r level-3/advanced/terraform my-tf-module
+   cp level-3/advanced/terraform/* my-tf-module
    cp -r level-3/function my-tf-module
    ```
 

--- a/README.md
+++ b/README.md
@@ -958,7 +958,7 @@ To reach level 5, you'll need to learn how to decouple multiple functions asynch
 1. Copy the updated function code to your working directory
 
    ```shell
-   cp -r level-5/advanced/terraform/* my-tf-module
+   cp level-5/advanced/terraform/* my-tf-module
    cp -r level-5/function my-tf-module
    ```
 

--- a/level-3/advanced/terraform/function.tf
+++ b/level-3/advanced/terraform/function.tf
@@ -25,7 +25,7 @@ resource "aws_lambda_function" "my_function" {
 data "archive_file" "lambda_my_function" {
   type = "zip"
 
-  source_dir  = "${path.module}/../function"
+  source_dir  = "${path.module}/function"
   output_path = "${path.module}/function.zip"
 }
 


### PR DESCRIPTION
- Level 3 used a wrong path for the terraform module
- Level 6 used wrong commands for the terraform moduel
- Level 5 used an inconsistent `cp` command